### PR TITLE
Generate .SRCINFO after generating PKGBUILD.

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -32,5 +32,5 @@ All "constants" are either provided as class properties or at the bottom of the 
 ## TODO
 
 * Dynamically generate info on static (included in repository) sources.
-* Run makepkg --printsrcinfo to update .SRCINFO. 
+* ~~Run makepkg --printsrcinfo to update .SRCINFO.~~
 * Provide feedback when generating checksums.


### PR DESCRIPTION
Implemented the most important TODO. Updating the package really should be as simple as running pkgbuild_generator.py.

If it is not desirable to always generate the .SRCINFO file let me know and I will add a cli with suitable switches